### PR TITLE
Updated to work with the latest on master of ofxMSAInteractiveObject. Example project now works

### DIFF
--- a/src/shapes/ofxMtlMapping2DPolygon.cpp
+++ b/src/shapes/ofxMtlMapping2DPolygon.cpp
@@ -171,7 +171,7 @@ void ofxMtlMapping2DPolygon::updatePosition(int xInc, int yInc)
     list<ofxMtlMapping2DVertex*>::iterator it;
 	for (it=vertices.begin(); it!=vertices.end(); it++) {
 		ofxMtlMapping2DVertex* vertex = *it;
-		vertex->setPos(vertex->x + xInc, vertex->y + yInc);
+		vertex->setPosition(vertex->x + xInc, vertex->y + yInc);
         vertex->updateCenter();
 	}
     
@@ -222,7 +222,7 @@ void ofxMtlMapping2DPolygon::updatePolyline()
     
     // ---- Interactive obj
     boundingBox = polyline->getBoundingBox();
-    setPos(boundingBox.x, boundingBox.y);
+    setPosition(boundingBox.x, boundingBox.y);
     setSize(boundingBox.width, boundingBox.height);
 }
 

--- a/src/shapes/ofxMtlMapping2DVertex.cpp
+++ b/src/shapes/ofxMtlMapping2DVertex.cpp
@@ -28,7 +28,7 @@ ofxMtlMapping2DVertex::~ofxMtlMapping2DVertex()
 void ofxMtlMapping2DVertex::init(float _x, float _y, int _index) 
 {
 	index = _index;
-    setPos(_x, _y);
+    setPosition(_x, _y);
 	
 	//Center
 	updateCenter();
@@ -41,7 +41,7 @@ void ofxMtlMapping2DVertex::kill()
 		activeVertex = NULL;
 	}
     
-    killMe();
+    delete this;
 }
 
 //--------------------------------------------------------------
@@ -54,7 +54,7 @@ void ofxMtlMapping2DVertex::update()
 void ofxMtlMapping2DVertex::drawBack()
 {
     ofFill();
-    if(isMouseDown() || activeVertex == this) {
+    if(activeVertex == this) {
         ofSetColor(255, 255, 255, 150);
         ofCircle(x+15, y+15, 20);
     } else if(isMouseOver()) {
@@ -69,7 +69,7 @@ void ofxMtlMapping2DVertex::drawBack()
 void ofxMtlMapping2DVertex::drawTop()
 {
     ofNoFill();
-    if(isMouseDown() || activeVertex == this) {
+    if(activeVertex == this) {
         ofSetColor(255, 255, 0, 150);
     } else if(isMouseOver()) {
         ofSetColor(255, 0, 0, 120);
@@ -96,7 +96,7 @@ void ofxMtlMapping2DVertex::updateCenter()
 //--------------------------------------------------------------
 void ofxMtlMapping2DVertex::snapIt(float _x, float _y) 
 {
-    setPos(_x, _y);
+    setPosition(_x, _y);
     updateCenter();
 }
 
@@ -106,25 +106,29 @@ void ofxMtlMapping2DVertex::snapIt(float _x, float _y)
 //--------------------------------------------------------------
 void ofxMtlMapping2DVertex::left() 
 {
-    snapIt(x-1, y);
+    if(activeVertex)
+        snapIt(x-1, y);
 }
 
 //--------------------------------------------------------------
 void ofxMtlMapping2DVertex::up() 
 {
-    snapIt(x, y-1);
+    if(activeVertex)
+        snapIt(x, y-1);
 }
 
 //--------------------------------------------------------------
 void ofxMtlMapping2DVertex::right() 
 {
-    snapIt(x+1, y);
+    if(activeVertex)
+        snapIt(x+1, y);
 }
 
 //--------------------------------------------------------------
 void ofxMtlMapping2DVertex::down() 
 {
-    snapIt(x, y+1);
+    if(activeVertex)
+        snapIt(x, y+1);
 }
 
 


### PR DESCRIPTION
Hi, just got the latest form master from your (wonderful) project and from the dependencies and the "ofxMSAInteractiveObject" seems to have been updated and does not work out of the box, in particular due to the following commits:

https://github.com/memo/ofxMSAInteractiveObject/commit/c8b66347df047ddfdc572e5f8ef94e1bfc6990e5#diff-a41973565e0f3559262fa1030eb1cfde
https://github.com/memo/ofxMSAInteractiveObject/commit/c698272643d2fb60ca1c3d38831af5164c975369#diff-a41973565e0f3559262fa1030eb1cfde
https://github.com/memo/ofxMSAInteractiveObject/commit/414b13fc3efb3d7af0bdb5cf8f091bf5afa38533#diff-a41973565e0f3559262fa1030eb1cfde

In a nutshell the changes are:
- updated the setPos() to setPosition().
- compensated for the lack of the killMe() method.
- removed the deprecated isMouseDown() as I don't see how it is needed (I might be wrong, though it works fine).
- added a check in the snapIt() method as the app could crash if a vertex was selected, then the parent shape selected and then an arrow key pressed.

Please review as I might have missed something.
